### PR TITLE
Added ppc64le to architecture list

### DIFF
--- a/telegram-desktop.spec
+++ b/telegram-desktop.spec
@@ -24,7 +24,7 @@ Source0: %{url}/releases/download/v%{version}/%{appname}-%{version}-full.tar.gz
 
 # Telegram Desktop require more than 8 GB of RAM on linking stage.
 # Disabling all low-memory architectures.
-ExclusiveArch: x86_64 aarch64
+ExclusiveArch: x86_64 aarch64 ppc64le
 
 BuildRequires: cmake(Microsoft.GSL)
 BuildRequires: cmake(OpenAL)


### PR DESCRIPTION
Tested on a POWER9 machine running Fedora 36.

The following dependencies also needed updates to build on ppc64le:
 * [tg_owt](https://github.com/rpmfusion/tg_owt/pull/1)
 * [libdispatch (MERGED)](https://src.fedoraproject.org/rpms/libdispatch/c/0a566608a7d292bbfd55078678a83ca21af08047?branch=rawhide)